### PR TITLE
fix for python 3+ and latest numpy

### DIFF
--- a/python/entropy.py
+++ b/python/entropy.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 import cv2
 import numpy as np
+import os.path as path
 
 
 def calcEntropy(img):
@@ -17,13 +18,15 @@ def calcEntropy(img):
             en = -1 * probability * (np.log(probability) / np.log(2))
         entropy.append(en)
 
-    sum_en = np.sum(entropy)
+    arr = np.asarray(entropy, dtype="object")
+    sum_en = np.sum(arr)
     return sum_en
 
 
 if __name__ == '__main__':
-    img1 = cv2.imread("../imgs/img1.jpg", cv2.IMREAD_GRAYSCALE)
-    img2 = cv2.imread("../imgs/img2.jpg", cv2.IMREAD_GRAYSCALE)
+    currentFilePath = path.dirname(path.realpath(__file__))
+    img1 = cv2.imread(currentFilePath + "/../imgs/img1.jpg", cv2.IMREAD_GRAYSCALE)
+    img2 = cv2.imread(currentFilePath + "/../imgs/img2.jpg", cv2.IMREAD_GRAYSCALE)
 
     entropy1 = calcEntropy(img1)
     entropy2 = calcEntropy(img2)


### PR DESCRIPTION
This commit fixes the following error line 
```The requested array has an inhomogeneous shape after 1 dimensions```
which is thrown at the following line
```sum_en = np.sum(entropy)```. 
Moreover, running in VSCode debugger faced an error in the following line 
```img1 = cv2.imread("../imgs/img1.jpg", cv2.IMREAD_GRAYSCALE)```
which is fixed in this commit.